### PR TITLE
Responsive Footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -9,7 +9,7 @@ export default class Footer extends Component {
     return (
       <div className='footer'>
         <div className='footerContent'>
-          <h2>Share the love</h2>
+          <h2>Sosialt</h2>
           <div className="sections">
 
             <div className='section'>
@@ -28,9 +28,7 @@ export default class Footer extends Component {
             <div className="section">
               <iframe
                 src="https://www.facebook.com/plugins/page.php?href=https%3A%2F%2Fwww.facebook.com%2FAbakusNTNU%2F&tabs=timeline&width=420&small_header=true&adapt_container_width=true&hide_cover=false&show_facepile=true&appId=1717809791769695"
-                width="100%"
-                height="100%"
-                style={{ border: "none", overflow: "hidden" }}
+                style={{ border: "none", overflow: "hidden", height: "325px", width: "100%" }}
                 scrolling="no"
                 frameBorder="0"
                 allowTransparency="true">
@@ -102,7 +100,27 @@ export default class Footer extends Component {
 
           .credit {
             font-size: 12px;
-            margin-top: 40px;
+            margin: 40px 0 10px;
+          }
+
+          @media (max-width: 800px) {
+            .footerContent {
+              padding: 0 30px;
+            }
+
+            .footer h2 {
+              margin-bottom: 25px;
+            }
+
+            .sections {
+              flex-direction: column;
+            }
+
+            .section {
+              border-right: none;
+              margin-bottom: 30px;
+              padding: 0;
+            }
           }
         `}
         </style>


### PR DESCRIPTION
The Facebook component isn't very dynamic, so it's width doesn't match the site width most of the time. This PR at least puts twitter and facebook in a column when they dont fit in a row, so they're at least completely visible the entire time.

I also changed the title of the footer to `Connect`, `Share the love` was a bit cheesy 😛 

Good (just this exact width):
<img width="483" alt="skjermbilde 2017-02-23 kl 16 11 03" src="https://cloud.githubusercontent.com/assets/14221386/23264925/4cd815a0-f9e3-11e6-8978-a16320a39a21.png">

Bad:
<img width="750" alt="skjermbilde 2017-02-23 kl 16 32 03" src="https://cloud.githubusercontent.com/assets/14221386/23265680/a7115a66-f9e5-11e6-8705-62412ef5debb.png">
