### PR TITLE
Descriptions

### DIFF
--- a/events.js
+++ b/events.js
@@ -6,41 +6,48 @@ export default [{
   endsAt: parse('March 13, 2017 15:00'),
   location: 'Downtown',
   link: 'https://abakus.no/event/123',
-  description: 'Abakus inviterer til en heidundranes kveld med strikking og drikking.'
+  description: 'Jubileumsuken er i gang, og det håper vi at du også er! Vi kickstarter uken med en spennende lek Vil du påstå at du har et øye for detaljer? Rundt omkring i kriker og kroker på Gløshaugen gjemmer det seg noe helt spesielt.'
 }, {
   title: 'Slipp av lang proggekonk',
   startsAt: parse('March 13, 2017 12:00')
 }, {
   title: 'Kurs med Capra Consulting',
   startsAt: parse('March 13, 2017 16:00'),
-  endsAt: parse('March 13, 2017 23:59')
+  endsAt: parse('March 13, 2017 23:59'),
+  description: 'Kunne du tenke deg å utvikle noe greier for mobile plattformer men også tilegne deg kunnskap som er så og si direkte anvendbart for generell frontendutvikling i JavaScript? Da kan dette kurset i React Native være noe for deg.'
 }, {
   title: 'π-dagen',
   startsAt: parse('March 14, 2017 10:00'),
   endsAt: parse('March 14, 2017 15:00'),
-  location: '',
+  location: 'Kontoret',
+  description: 'Gjør deg klar for nok en gøyal dag på kontoret! I dag feirer vi Π-dagen. Den matematiske konstanten som er definert som forholdet mellom omkretsen og diameteren til en sirkel har fått en stor plass i hjerte til enhver gløsing.'
 }, {
   title: 'Quiz Koskom',
   startsAt: parse('March 14, 2017 12:00')
 }, {
   title: 'Pub-til-pub med Bekk',
-  startsAt: parse('March 14, 2017 18:00'),
-  description: 'Konsert med Ababand ved siste bar'
+  startsAt: parse('March 14, 2017 17:00'),
+  description: 'BEKK arrangerer Pub-til-Pub Rebus! Oppmøte foran Hovedbygget hvor vi tar felles buss ned til midtbyen for bespisning. Deretter danner vi lag og starter Pub-til-Pub runden, hvor det vil være ulike poster på hvert sted. Velkommen!'
 }, {
   title: 'Barnas dag',
   startsAt: parse('March 15, 2017 10:00'),
+  description: 'Abakus blir 40 år og midtlivskrisen slår til. Det er ikke noe bedre tidspunkt å slå til med aktiviteter som får en til å føle seg som et barn igjen!'
 }, {
   title: 'LAN',
   startsAt: parse('March 15, 2017 16:00'),
+  description: 'Onsdag 15. mars er det klart for LAN på P15. Det blir god stemning, med mange kule konkurranser, fete premier og selvfølgelig pizza!'
 }, {
   title: 'Kaketorsdag (stor kake)',
-  startsAt: parse('March 16, 2017 10:00')
+  startsAt: parse('March 16, 2017 10:00'),
+  description: 'Ordet jubileum eksisterer ikke uten ordet kake, så i dag feirer vi 40 år med et stykke kunst av et bakstverk. Dette er ukas beste mulighet for å sette sommerkroppen på vent og glede ditt usynlige deg med endorfiner bare et sukkerrush fra en annen verden kan gi deg.'
 }, {
   title: 'Revy',
-  startsAt: parse('March 16, 2017 18:30')
+  startsAt: parse('March 16, 2017 19:30'),
+  description: '16. og 17. mars spiller Abakus sin aller første revy på byscenen. Billetter kjøpes på byscenen.no'
 }, {
   title: 'Labamba premierefest',
-  startsAt: parse('March 16, 2017 21:00')
+  startsAt: parse('March 16, 2017 21:30'),
+  description: 'Har revyen gitt deg sommerfugler i magen og vekket danskefoten? Vi vet hvor du kan slippe deg løs! Etter premieren til Abakusrevyen, torsdag 16 mars, står LaBamba klare til å serve deg på Trondhjem Seilforening.  Og husk, cash is king!'
 }, {
   title: 'Alumnidag + dåp',
   startsAt: parse('March 17, 2017 10:00')
@@ -49,8 +56,10 @@ export default [{
   startsAt: parse('March 17, 2017 12:00')
 }, {
   title: 'Revy',
-  startsAt: parse('March 17, 2017 19:30')
+  startsAt: parse('March 17, 2017 19:30'),
+  description: '16. og 17. mars spiller Abakus sin aller første revy på byscenen. Billetter kjøpes på byscenen.no'
 }, {
   title: 'GALLA',
-  startsAt: parse('March 18, 2017 18:00')
+  startsAt: parse('March 18, 2017 18:00'),
+  description: 'Lørdag 18. mars klokken 18:00 er det duket for studentergalla på Scandic Lerkendal. Det vil bli servert 2-retters middag samt to drikkeenheter. Det blir storartet underholdning fra start til slutt, og Ababand skal selvfølgelig spille. Rundt midnatt forflytter vi oss til nach der festlighetene fortsetter utover natten.'
 }];


### PR DESCRIPTION
I added most of the descriptions from the provided document. There are a couple discrepancies:

These events are still **missing descriptions** (didn't find them in the document):
- Slipp av lang proggekonk
- Quiz Koskom
- Alumnidag + dåp
- Gjettelek

There are also some descriptions in the document with **no corresponding events**:
- Åpningsfest
- Frokostfredag